### PR TITLE
Follow-up patch for #848616 to match upstream

### DIFF
--- a/debian/mariadb-server-10.1.postinst
+++ b/debian/mariadb-server-10.1.postinst
@@ -114,7 +114,7 @@ EOF
     # Debian: beware of the bashisms...
     # Debian: can safely run on upgrades with existing databases
     set +e
-    bash /usr/bin/mysql_install_db --skip-auth-anon --auth-root-socket --rpm --cross-bootstrap --user=mysql --disable-log-bin 2>&1 | $ERR_LOGGER
+    bash /usr/bin/mysql_install_db --skip-auth-anonymous-user --auth-root-authentication-method=socket --rpm --cross-bootstrap --user=mysql --disable-log-bin 2>&1 | $ERR_LOGGER
     set -e
 
 

--- a/debian/patches/mysql_install_db_auth_options.patch
+++ b/debian/patches/mysql_install_db_auth_options.patch
@@ -8,63 +8,75 @@ Description: Extend mysql_install_db to allow to create a secure initial root
 
 --- a/scripts/mysql_install_db.sh
 +++ b/scripts/mysql_install_db.sh
-@@ -34,11 +34,20 @@ force=0
+@@ -34,11 +34,26 @@ force=0
  in_rpm=0
  ip_only=0
  cross_bootstrap=0
 +install_params=""
++auth_root_authentication_method=normal
++auth_root_socket_user='root'
  
  usage()
  {
    cat <<EOF
  Usage: $0 [OPTIONS]
-+  --auth-root-nopasswd Install the root account with no password authentication
-+                       (default, overridden by --auth-root-socket).
-+  --auth-root-socket[=user]
-+                       Install the root account with unix socket authentication.
-+                       This allows only the system root user to login as
-+                       MariaDB root. If "user" is specified, it is the name
-+                       of the MariaDB root account as well as of the system
-+                       account allowed to access it.
++  --auth-root-authentication-method=normal|socket
++                       Chooses the authentication method for the created initial
++                       root user. The default is 'normal' to creates a root user
++                       that can login without password, which can be insecure.
++                       The alternative 'socket' allows only the system root user
++                       to login as MariaDB root; this requires the unix socket
++                       authentication plugin.
++  --auth-root-socket-user=user
++                       Used with --auth-root-authentication-method=socket. It
++                       specifies the name of the MariaDB root account, as well
++                       as of the system account allowed to access it. Defaults
++                       to 'root'.
    --basedir=path       The path to the MariaDB installation directory.
    --builddir=path      If using --srcdir with out-of-directory builds, you
                         will need to set this to the location of the build
-@@ -59,6 +68,7 @@ Usage: $0 [OPTIONS]
+@@ -59,6 +74,8 @@ Usage: $0 [OPTIONS]
    --defaults-file=path Read only this configuration file.
    --rpm                For internal use.  This option is used by RPM files
                         during the MariaDB installation process.
-+  --skip-auth-anon     Do not install an unprivileged anonymous user.
++  --skip-auth-anonymous-user
++                       Do not install an unprivileged anonymous user.
    --skip-name-resolve  Use IP addresses rather than hostnames when creating
                         grant table entries.  This option can be useful if
                         your DNS does not work.
-@@ -141,6 +151,22 @@ parse_arguments()
+@@ -141,6 +158,17 @@ parse_arguments()
          #
          # --windows is a deprecated alias
          cross_bootstrap=1 ;;
-+      --skip-auth-anon)
++      --skip-auth-anonymous-user)
 +	install_params="$install_params
 +SET @skip_auth_anonymous=1;" ;;
-+      --auth-root-nopasswd)
-+	install_params="$install_params
-+SET @skip_auth_root_nopasswd=NULL;
-+SET @auth_root_socket=NULL;" ;;
-+      --auth-root-socket)
-+	install_params="$install_params
-+SET @skip_auth_root_nopasswd=1;
-+SET @auth_root_socket='root';" ;;
-+      --auth-root-socket=*)
-+        root_name="$(parse_arg "$arg")"
-+	install_params="$install_params
-+SET @skip_auth_root_nopasswd=1;
-+SET @auth_root_socket='$root_name';" ;;
++      --auth-root-authentication-method=normal)
++	auth_root_authentication_method=normal ;;
++      --auth-root-authentication-method=socket)
++	auth_root_authentication_method=socket ;;
++      --auth-root-authentication-method=*)
++        usage ;;
++      --auth-root-socket-user=*)
++        auth_root_socket_user="$(parse_arg "$arg")" ;;
  
        *)
          if test -n "$pick_args"
-@@ -430,7 +456,7 @@ mysqld_install_cmd_line()
+@@ -430,7 +458,17 @@ mysqld_install_cmd_line()
  
  # Create the system and help tables by passing them to "mysqld --bootstrap"
  s_echo "Installing MariaDB/MySQL system tables in '$ldata' ..."
 -if { echo "use mysql;"; cat "$create_system_tables" "$create_system_tables2" "$fill_system_tables"; } | eval "$filter_cmd_line" | mysqld_install_cmd_line > /dev/null
++case "$auth_root_authentication_method" in
++  normal)
++    install_params="$install_params
++SET @skip_auth_root_nopasswd=NULL;
++SET @auth_root_socket=NULL;" ;;
++  socket)
++    install_params="$install_params
++SET @skip_auth_root_nopasswd=1;
++SET @auth_root_socket='$auth_root_socket_user';" ;;
++esac
 +if { echo "use mysql;$install_params"; cat "$create_system_tables" "$create_system_tables2" "$fill_system_tables"; } | eval "$filter_cmd_line" | mysqld_install_cmd_line > /dev/null
  then
    s_echo "OK"


### PR DESCRIPTION
The upstream naming of the new mysql_install_db options were changed
post-review.

Update the debian patch and mariadb-server-10.1 accordingly to match
upstream. The new options will be available in upstream MariaDB
10.1.21.