### PR TITLE
Allow mariadb-plugin-tokudb/mroonga on non-linux and non-release arches

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -360,7 +360,7 @@ Description: OQGraph storage engine for MariaDB
  This package contains the OQGraph plugin for MariaDB.
 
 Package: mariadb-plugin-tokudb
-Architecture: amd64
+Architecture: base-any-any-amd64
 Depends: mariadb-server-10.1, ${misc:Depends}, ${shlibs:Depends}
 Breaks: mariadb-server-10.0, mariadb-server-10.1 (<< ${source:Version})
 Replaces: mariadb-server-10.0, mariadb-server-10.1 (<< ${source:Version})
@@ -371,7 +371,8 @@ Description: TokuDB storage engine for MariaDB
  This package contains the TokuDB plugin for MariaDB.
 
 Package: mariadb-plugin-mroonga
-Architecture: amd64 arm64 armel armhf i386 mips64el mipsel ppc64el
+# Supports little-endian architectures only
+Architecture: any-i386 any-ia64 any-alpha any-amd64 any-arm any-arm64 any-mipsel any-mipsr6el any-mips64el any-mips64r6el any-nios2 any-powerpcel any-ppc64el any-sh3 any-sh4 any-tilegx
 Depends: mariadb-server-10.1, ${misc:Depends}, ${shlibs:Depends}
 Breaks: mariadb-server-10.0, mariadb-server-10.1 (<< ${source:Version})
 Replaces: mariadb-server-10.0, mariadb-server-10.1 (<< ${source:Version})

--- a/debian/rules
+++ b/debian/rules
@@ -14,6 +14,8 @@ BUILDDIR := builddir
 DEB_HOST_GNU_TYPE  ?= $(shell dpkg-architecture -qDEB_HOST_GNU_TYPE)
 DEB_BUILD_GNU_SYSTEM ?= $(shell dpkg-architecture -qDEB_BUILD_GNU_SYSTEM)
 DEB_BUILD_ARCH ?= $(shell dpkg-architecture -qDEB_BUILD_ARCH)
+DEB_BUILD_ARCH_ABI ?= $(shell dpkg-architecture -qDEB_BUILD_ARCH_ABI)
+DEB_BUILD_ARCH_CPU ?= $(shell dpkg-architecture -qDEB_BUILD_ARCH_CPU)
 DEB_BUILD_ARCH_OS ?= $(shell dpkg-architecture -qDEB_BUILD_ARCH_OS)
 DEBVERSION := $(shell dpkg-parsechangelog | awk '/^Version: / { print $$2 }' | sed 's/^.*-//' )
 DEB_SOURCE_PACKAGE ?= $(strip $(shell egrep '^Source: ' debian/control | cut -f 2 -d ':'))
@@ -48,7 +50,9 @@ else
 endif
 
 # Skip TokuDB if arch is not amd64
-ifneq ($(ARCH), amd64)
+# Skipped on the x32 ABI too; untested, but unlikely to work given i386 is not
+# supported.
+ifneq ($(DEB_HOST_ARCH_ABI)-$(DEB_HOST_ARCH_CPU), base-amd64)
     CMAKEFLAGS += -DWITHOUT_TOKUDB=true
 endif
 


### PR DESCRIPTION
This is the same as the patch I followed up on https://bugs.debian.org/852709 with, but as a GitHub pull request for your convenience.