### PR TITLE
Detect whether libatomic is needed rather than hard-coding for mips

### DIFF
--- a/debian/patches/c11_atomics.patch
+++ b/debian/patches/c11_atomics.patch
@@ -10,10 +10,38 @@ Author: Vicențiu Ciorbaru <vicentiu@mariadb.org>
    FIND_PACKAGE(Threads)
  
 -  SET(CMAKE_REQUIRED_LIBRARIES 
-+  SET(CMAKE_REQUIRED_LIBRARIES ${EXTRA_REQ_LIBRARIES}
++  LIST(APPEND CMAKE_REQUIRED_LIBRARIES
      ${LIBM} ${LIBNSL} ${LIBBIND} ${LIBCRYPT} ${LIBSOCKET} ${LIBDL} ${CMAKE_THREAD_LIBS_INIT} ${LIBRT} ${LIBEXECINFO})
    # Need explicit pthread for gcc -fsanitize=address
    IF(CMAKE_USE_PTHREADS_INIT AND CMAKE_C_FLAGS MATCHES "-fsanitize=")
+@@ -1028,7 +1028,26 @@ ELSEIF(NOT WITH_ATOMIC_OPS)
+     long long int *ptr= &var;
+     return (int)__atomic_load_n(ptr, __ATOMIC_SEQ_CST);
+   }"
+-  HAVE_GCC_C11_ATOMICS)
++  HAVE_GCC_C11_ATOMICS_WITHOUT_LIBATOMIC)
++  IF(HAVE_GCC_C11_ATOMICS_WITHOUT_LIBATOMIC)
++    SET(HAVE_GCC_C11_ATOMICS True)
++  ELSE()
++    SET(OLD_CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES})
++    LIST(APPEND CMAKE_REQUIRED_LIBRARIES "atomic")
++    CHECK_CXX_SOURCE_COMPILES("
++    int main()
++    {
++      long long int var= 1;
++      long long int *ptr= &var;
++      return (int)__atomic_load_n(ptr, __ATOMIC_SEQ_CST);
++    }"
++    HAVE_GCC_C11_ATOMICS_WITH_LIBATOMIC)
++    IF(HAVE_GCC_C11_ATOMICS_WITH_LIBATOMIC)
++      SET(HAVE_GCC_C11_ATOMICS True)
++    ELSE()
++      SET(CMAKE_REQUIRED_LIBRARIES ${OLD_CMAKE_REQUIRED_LIBRARIES})
++    ENDIF()
++  ENDIF()
+ ELSE()
+   MESSAGE(FATAL_ERROR "${WITH_ATOMIC_OPS} is not a valid value for WITH_ATOMIC_OPS!")
+ ENDIF()
 --- a/include/atomic/gcc_builtins.h
 +++ b/include/atomic/gcc_builtins.h
 @@ -16,6 +16,7 @@
@@ -71,7 +99,7 @@ Author: Vicențiu Ciorbaru <vicentiu@mariadb.org>
    TARGET_LINK_LIBRARIES(mysys bfd)  
  ENDIF(HAVE_BFD_H)
  
-+IF (EXTRA_REQ_LIBRARIES MATCHES "atomic")
++IF(HAVE_GCC_C11_ATOMICS_WITH_LIBATOMIC)
 +  TARGET_LINK_LIBRARIES(mysys atomic)
 +ENDIF()
 +
@@ -84,7 +112,7 @@ Author: Vicențiu Ciorbaru <vicentiu@mariadb.org>
    ${SSL_LIBRARIES}
    ${LIBSYSTEMD})
  
-+IF (EXTRA_REQ_LIBRARIES MATCHES "atomic")
++IF(HAVE_GCC_C11_ATOMICS_WITH_LIBATOMIC)
 +  TARGET_LINK_LIBRARIES(sql atomic)
 +ENDIF()
 +

--- a/debian/patches/remove-systemd-obsolete-target.patch
+++ b/debian/patches/remove-systemd-obsolete-target.patch
@@ -11,7 +11,7 @@ Author: Otto Kekäläinen <otto@mariadb.org>
  Description=MariaDB database server
  After=network.target
 -After=syslog.target
-
+ 
  [Install]
  WantedBy=multi-user.target
 --- a/support-files/mariadb@.service.in
@@ -21,5 +21,6 @@ Author: Otto Kekäläinen <otto@mariadb.org>
  Description=MariaDB database server
  After=network.target
 -After=syslog.target
-
+ 
  ConditionPathExists=@INSTALL_SYSCONF2DIR@/my%I.cnf
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -17,5 +17,5 @@ mips-machine.patch
 mips-unstable-tests.patch
 hurd_socket.patch
 armhf_mroonga_storage_fail.patch
-mips_64_atomic.patch
+c11_atomics.patch
 remove-systemd-obsolete-target.patch

--- a/debian/rules
+++ b/debian/rules
@@ -44,7 +44,6 @@ endif
 # Ignore test suite exit code on unstable platforms
 ifneq (,$(filter $(ARCH), mips mipsel))
     TESTSUITE_FAIL_CMD:=true
-    EXTRA_REQ_LIBARIES:=atomic
 else
     TESTSUITE_FAIL_CMD:=exit 1
 endif
@@ -97,7 +96,6 @@ endif
 	    -DINSTALL_PLUGINDIR=lib/$(DEB_HOST_MULTIARCH)/mariadb18/plugin \
 	    -DINSTALL_MYSQLTESTDIR=share/mysql/mysql-test \
 	    -DPLUGIN_AUTH_SOCKET=STATIC \
-	    -DEXTRA_REQ_LIBRARIES="$(EXTRA_REQ_LIBARIES)" \
 	    -DDEB=$(DISTRIBUTION) ..'
 	touch $@
 


### PR DESCRIPTION
Fixes FTBFS on powerpc, since it needs libatomic too for C11 atomics, and possibly m68k. I haven't actually tested a full build, but configuring now detects that it can use C11 atomics with libatomic, so it should at least get further:

````
-- Performing Test HAVE_GCC_ATOMIC_BUILTINS
-- Performing Test HAVE_GCC_ATOMIC_BUILTINS - Failed
-- Performing Test HAVE_GCC_C11_ATOMICS_WITHOUT_LIBATOMIC
-- Performing Test HAVE_GCC_C11_ATOMICS_WITHOUT_LIBATOMIC - Failed
-- Performing Test HAVE_GCC_C11_ATOMICS_WITH_LIBATOMIC
-- Performing Test HAVE_GCC_C11_ATOMICS_WITH_LIBATOMIC - Success
````