### PR TITLE
Fix Mroonga compilation failure on arm64

### DIFF
--- a/debian/patches/0026-Mroonga-fix-ice-arm64.patch
+++ b/debian/patches/0026-Mroonga-fix-ice-arm64.patch
@@ -1,0 +1,22 @@
+From: Vicentiu Ciorbaru <cvicentiu@gmail.com>
+
+Subject: Workaround for ICE in mroonga on Arm64 architecture
+Details: There seems to be a bug in gcc-6.3.0 on arm64 where it fails
+to compile a file which makes use of the not_equal_float function.
+A basic logic workaround solves the problem by calling the equal_float
+function instead.
+
+
+diff --git a/storage/mroonga/vendor/groonga/lib/ts/ts_expr_node.c b/storage/mroonga/vendor/groonga/lib/ts/ts_expr_node.c
+index 44378cfa..a3d838c3 100644
+--- a/storage/mroonga/vendor/groonga/lib/ts/ts_expr_node.c
++++ b/storage/mroonga/vendor/groonga/lib/ts/ts_expr_node.c
+@@ -562,7 +562,7 @@ inline static grn_ts_bool
+ grn_ts_op_not_equal_float(grn_ts_float lhs, grn_ts_float rhs)
+ {
+   /* To suppress warnings, "lhs != rhs" is not used. */
+-  return (lhs < rhs) || (lhs > rhs);
++  return !grn_ts_op_equal_float(lhs, rhs);
+ }
+ 
+ /* grn_ts_op_not_equal_time() returns lhs != rhs. */

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -23,3 +23,4 @@ mytop-merge_src:mytop_improvements.patch
 Add_default_ExecStartPre_to_mariadb@.service.patch
 0024-Revert-to-using-system-pcre-library.patch
 0025-Change-the-default-optimization-from-O3-to-O2-in-mys.patch
+0026-Mroonga-fix-ice-arm64.patch


### PR DESCRIPTION
There is an internal compiler error on GCC-6.3.0 on arm64.
Workaround the error by making use of different function to
compare floats.